### PR TITLE
2021-10-05 GUARD-2167 WooCommerce FullInventorySync-DuplicateKey-Added-Issue-And-Logz

### DIFF
--- a/src/WooCommerceAccess/Models/Product.cs
+++ b/src/WooCommerceAccess/Models/Product.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using CuttingEdge.Conditions;
+using WooCommerceAccess.Shared;
 using WooCommerceNET.WooCommerce.Legacy;
 using WooCommerceNET.WooCommerce.v3;
 
@@ -92,7 +93,8 @@ namespace WooCommerceAccess.Models
 
 		public static Dictionary< string, string > ToAttributeDictionary( this List< ProductAttributeLine > attributeLines )
 		{
-			return attributeLines.Where( a => !string.IsNullOrWhiteSpace( a.name ) && a.options != null && a.options.Count == 1)
+			return attributeLines.Where( a => !string.IsNullOrWhiteSpace( a.name ) && a.options != null && a.options.Count > 0 )
+				.DistinctBy( a => a.name )
 				.ToDictionary( a => a.name, a => a.options.First() );
 		}
 

--- a/src/WooCommerceAccess/Shared/EnumerableHelper.cs
+++ b/src/WooCommerceAccess/Shared/EnumerableHelper.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace WooCommerceAccess.Shared
+{	
+    public static class EnumerableHelper
+    {
+        public static IEnumerable< TSource > DistinctBy< TSource, TKey >( this IEnumerable< TSource > source, Func< TSource, TKey > keySelector )
+        {
+            var identifiedKeys = new HashSet< TKey >();
+            return source.Where( element => identifiedKeys.Add( keySelector( element ) ) );
+        }
+    }
+}

--- a/src/WooCommerceAccess/Shared/Misc.cs
+++ b/src/WooCommerceAccess/Shared/Misc.cs
@@ -1,7 +1,6 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using System;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
 
@@ -18,7 +17,7 @@ namespace WooCommerceAccess.Shared
 			{
 				Uri uri = new Uri( url );
 
-				serviceEndPoint = uri.LocalPath;
+				serviceEndPoint = uri.AbsoluteUri;
 				requestParameters = uri.Query;
 			}
 


### PR DESCRIPTION
FullInventorySync regularly crashes for one of the Tenants. There are three different errors periodically in the logz:

1) "Unsupported WordPress and WooCommerce version!" - this error occurs from time to time, but it is difficult to say exactly what it is related with. This occurs in the DetectApiVersion method in case when it is not possible to receive an http200 request to the "wp-json/wc/v3" endpoint or http401 to “wc-api/v3/products” endpoint. 
That is, if at some point the marketplace api returns another http response code, then we will see "Unsupported WordPress and WooCommerce version!" At the same time, we didn't log the full url request / code / content of responses. I tried to reproduce the error with an integration test with the same credentials for this marketplace, but I was unable to reproduce. 
As part of the fix - I've addd aditionally loging to log full urls and responses in the TryGetV3JsonApiDescription and TryGetEntitiesWithLegacyApiV3 methods in case of errors. So I believe that this issue is probably on the WooCommerce side but we will able to inventigate the reason once the current fix will be released.

If the API version is detected successfully, then the synchronization is interrupted for one of the following reasons:

2) "Error establishing a database connection" - This is a strange bug on the marketplace side, probably their database is unavailable from time to time. I don't think we can do anything about it

3) "An item with the same key has already been added" - I found a reason and reproduced the issue. It occurs in the ToAttributeDictionary method in case if we receive a product with duplicated attributes (as example)
![image](https://user-images.githubusercontent.com/80940351/136004593-547b8b7f-fe75-4d4c-95b1-e6489c161693.png)
I think this is a bug in WooCommerce, however, we must cover for such a situation - I've applied the fix 
![image](https://user-images.githubusercontent.com/80940351/136005033-e27599a4-6227-44c1-b0ed-45636b947ecb.png)
