### PR TITLE
RLS-3133 GUARD-2492  WooCommerce FullInventorySync Duplicated ProductId Error

### DIFF
--- a/src/WooCommerceAccess/Configuration/WooCommerceCommandEndpointName.cs
+++ b/src/WooCommerceAccess/Configuration/WooCommerceCommandEndpointName.cs
@@ -4,6 +4,7 @@ namespace WooCommerceAccess.Configuration
 	{
 		public static readonly WooCommerceCommandEndpointName Page = new WooCommerceCommandEndpointName( "page" );
 		public static readonly WooCommerceCommandEndpointName PerPage = new WooCommerceCommandEndpointName( "per_page" );
+		public static readonly WooCommerceCommandEndpointName OrderBy = new WooCommerceCommandEndpointName("orderby");
 		public static readonly WooCommerceCommandEndpointName PerPageLegacyApiV3 = new WooCommerceCommandEndpointName( "filter[limit]");
 
 		private WooCommerceCommandEndpointName( string name )

--- a/src/WooCommerceAccess/Services/ApiV3WCObject.cs
+++ b/src/WooCommerceAccess/Services/ApiV3WCObject.cs
@@ -149,7 +149,15 @@ namespace WooCommerceAccess.Services
 
 			if ( productVariationsToUpdate.Any() )
 			{
-				variationsToUpdate.Add( new ProductId( productId ), productVariationsToUpdate );
+				var productIdKey = new ProductId( productId );
+				if ( variationsToUpdate.ContainsKey( productIdKey ) )
+				{
+					variationsToUpdate[ productIdKey ] = productVariationsToUpdate;
+				}
+				else
+				{
+					variationsToUpdate.Add( productIdKey, productVariationsToUpdate );
+				}
 			}
 		}
 

--- a/src/WooCommerceAccess/Services/EndpointsBuilder.cs
+++ b/src/WooCommerceAccess/Services/EndpointsBuilder.cs
@@ -12,6 +12,7 @@ namespace WooCommerceAccess.Services
 			{
 				{ WooCommerceCommandEndpointName.Page.Name, config.Page.ToString() },
 				{ WooCommerceCommandEndpointName.PerPage.Name, config.PerPage.ToString() },
+				{ WooCommerceCommandEndpointName.OrderBy.Name, "id" }
 			};
 		}
 
@@ -21,6 +22,7 @@ namespace WooCommerceAccess.Services
 			{
 				{ WooCommerceCommandEndpointName.Page.Name, config.Page.ToString() },
 				{ WooCommerceCommandEndpointName.PerPageLegacyApiV3.Name, config.PerPage.ToString() },
+				{ WooCommerceCommandEndpointName.OrderBy.Name, "id" }
 			};
 		}
 	}

--- a/src/WooCommerceAccess/Services/EndpointsBuilder.cs
+++ b/src/WooCommerceAccess/Services/EndpointsBuilder.cs
@@ -12,7 +12,7 @@ namespace WooCommerceAccess.Services
 			{
 				{ WooCommerceCommandEndpointName.Page.Name, config.Page.ToString() },
 				{ WooCommerceCommandEndpointName.PerPage.Name, config.PerPage.ToString() },
-				{ WooCommerceCommandEndpointName.OrderBy.Name, "id" }
+				{ WooCommerceCommandEndpointName.OrderBy.Name, "id" } // added sorting by id as a temporarily fix for know wooCommerce issue https://github.com/woocommerce/woocommerce/issues/32715
 			};
 		}
 
@@ -22,7 +22,7 @@ namespace WooCommerceAccess.Services
 			{
 				{ WooCommerceCommandEndpointName.Page.Name, config.Page.ToString() },
 				{ WooCommerceCommandEndpointName.PerPageLegacyApiV3.Name, config.PerPage.ToString() },
-				{ WooCommerceCommandEndpointName.OrderBy.Name, "id" }
+				{ WooCommerceCommandEndpointName.OrderBy.Name, "id" } // added sorting by id as a temporarily fix for know wooCommerce issue https://github.com/woocommerce/woocommerce/issues/32715
 			};
 		}
 	}

--- a/src/WooCommerceAccess/WooCommerceAccess.csproj
+++ b/src/WooCommerceAccess/WooCommerceAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl>https://github.com/skuvault/wooCommerceAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/wooCommerceAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/wooCommerceAccess</RepositoryUrl>
-    <Version>1.5.0.0</Version>
+    <Version>1.6.0.0-alpha</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.5.0.0</AssemblyVersion>
-    <FileVersion>1.5.0.0</FileVersion>
+    <AssemblyVersion>1.6.0.0</AssemblyVersion>
+    <FileVersion>1.6.0.0</FileVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
 

--- a/src/WooCommerceAccess/WooCommerceAccess.csproj
+++ b/src/WooCommerceAccess/WooCommerceAccess.csproj
@@ -8,12 +8,13 @@
     <Copyright>SkuVault © 2021-2022</Copyright>
     <PackageLicenseUrl>https://github.com/skuvault/wooCommerceAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/wooCommerceAccess</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/skuvault/wooCommerceAccess</RepositoryUrl>
+    <RepositoryUrl>https://github.com/skuvault-integrations/wooCommerceAccess.git</RepositoryUrl>
     <Version>1.6.0.0-alpha</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AssemblyVersion>1.6.0.0</AssemblyVersion>
     <FileVersion>1.6.0.0</FileVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WooCommerceAccess/WooCommerceAccess.csproj
+++ b/src/WooCommerceAccess/WooCommerceAccess.csproj
@@ -9,7 +9,7 @@
     <PackageLicenseUrl>https://github.com/skuvault/wooCommerceAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/wooCommerceAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault-integrations/wooCommerceAccess.git</RepositoryUrl>
-    <Version>1.6.0.0-alpha</Version>
+    <Version>1.6.0.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AssemblyVersion>1.6.0.0</AssemblyVersion>
     <FileVersion>1.6.0.0</FileVersion>

--- a/src/WooCommerceTests/VariationTests.cs
+++ b/src/WooCommerceTests/VariationTests.cs
@@ -240,5 +240,40 @@ namespace WooCommerceTests
 			Assert.AreEqual( variation.Sku.ToLower(), result.Sku.ToLower() );
 			Assert.AreEqual( skusQuantities[ Testsku ], result.Quantity );
 		}
+
+		[ Test ]
+		public void ApiV3WCObject_GetVariationsToUpdateWithDuplicatedProductId_ShouldPullMoreRecent()
+		{
+			var productId = 1;
+			int quantity1 = 10, quantity2 = 5;
+			var skusQuantities = new Dictionary< string, int >
+			{
+				{ Testsku, quantity2 }
+			};
+			var existingVariations = new List< WooCommerceVariation >
+			{
+				new WooCommerceVariation
+				{
+					Sku = Testsku,
+					Quantity = quantity1,
+					Id = 1,
+					ManagingStock = true
+				}
+			};
+			var variationsToUpdate = new Dictionary< ProductId, IEnumerable< QuantityUpdate > >
+			{
+				{ 
+					new ProductId( productId ),
+					new List< QuantityUpdate >()
+				}
+			};
+			
+			ApiV3WCObject.GetVariationsToUpdate( skusQuantities, existingVariations, productId, variationsToUpdate );
+
+			var variationsToUpdateItem = variationsToUpdate.First();
+			Assert.AreEqual( productId, variationsToUpdateItem.Key.Id );
+			Assert.AreEqual( skusQuantities.First().Key, variationsToUpdateItem.Value.First().Sku );
+			Assert.AreEqual( quantity2, variationsToUpdateItem.Value.First().Quantity );
+		}
 	}
 }


### PR DESCRIPTION
[RLS-3133]
**Problem**

Sometimes we got an exception "An item with the same key has already been added" in the GetProductsAndVariationsToUpdateAsync method while receiving products from wooCommerce page by page. The error says that at some point we are trying to add a new list of variations with the duplicated productId key. I confirmed problem in logz and it is known issue at wooCommerce side (still is in open status) - https://github.com/woocommerce/woocommerce/issues/32715

**Solution**

I applied two fixes:

- in case of a similar problem, at moment we replace the existing element with a newer one (this makes sense, since judging by the logs, the duplicates entries are almost completely identical)

- I also added sorting by orderby = id as suggested here - https://github.com/woocommerce/woocommerce/issues/32715. Note: as I see in the integration tests it sorts by "desc" by default, however the strange thing is that I was not able to sort it by order = "asc", although it is supported in the documentation - https://woocommerce.github.io/woocommerce-rest-api-docs/#list-all-products, the result is always sorted by "desc"

[RLS-3133]: https://agileharbor.atlassian.net/browse/RLS-3133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ