### PR TITLE
GUARD-2572 Orders Sync AVATAX Issue

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+# Description
+
+Tickets: [JIRA-1234] (Replace with appropriate tickets. Some automations depend on this section, don't remove)
+
+Summary of your changes, with screenshots if appropriate.
+Help us understand what you did. Describe how the code works and why it was done this way. You can also leave comments directly in the changed files to provide direct explanation, but check if it would be more appropriate to add those comments as inline comments in the code.
+
+## Type of change (should only be one)
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Functionality change (fix or feature that would cause existing functionality to work differently than before)
+- [ ] Configuration change
+- [ ] New / updated script
+- [ ] Refactoring
+- [ ] New tests to existing code
+
+Additional changes:
+- [ ] Confluence documentation updated - [link]
+
+# Additional Notes
+
+List things that we need to be aware of.
+* If these changes depend on a set of other changes in another repository or a pull request.
+* If your code has any known issues that are not being resolved as part of these changes, list them here.
+Remove this section if no additional notes.
+
+# PR Readiness Checklist
+
+Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it.
+
+- [ ] Followed [development conventions][1] to the best of my ability
+- [ ] Code is documented, particularly public interfaces and hard-to-understand areas
+- [ ] Tests are updated / added and all pass
+- [ ] Performed a self-review of my own code
+- [ ] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
+- [ ] Confluence documentation is updated, if needed
+- [ ] New code does not generate new warnings
+
+[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions

--- a/src/WooCommerceAccess/Services/ApiBasePath.cs
+++ b/src/WooCommerceAccess/Services/ApiBasePath.cs
@@ -1,0 +1,8 @@
+namespace WooCommerceAccess.Services
+{
+	internal static class ApiBasePath
+	{
+		internal const string V3 = "wp-json/wc/v3/";
+		internal const string LegacyV3 = "wc-api/v3";
+	}
+}

--- a/src/WooCommerceAccess/Services/BaseService.cs
+++ b/src/WooCommerceAccess/Services/BaseService.cs
@@ -45,10 +45,10 @@ namespace WooCommerceAccess.Services
 			if ( apiVersion == WooCommerceApiVersion.Unknown )
 				throw new WooCommerceException( "Unsupported WordPress and WooCommerce version!" );
 			
-			var legacyApiWcObject = new LegacyV3WCObject( new RestAPI( this.Config.ShopUrl + "wc-api/v3", this.Config.ConsumerKey, this.Config.ConsumerSecret, authorizedHeader: false ) );
+			var legacyApiWcObject = new LegacyV3WCObject( new RestAPI( this.Config.ShopUrl + ApiBasePath.LegacyV3, this.Config.ConsumerKey, this.Config.ConsumerSecret, authorizedHeader: false ) );
 				
 			if ( apiVersion == WooCommerceApiVersion.V3 )
-				this.WCObject = new ApiV3WCObject( new RestAPI( this.Config.ShopUrl + "wp-json/wc/v3/", this.Config.ConsumerKey, this.Config.ConsumerSecret, authorizedHeader: false ), legacyApiWcObject );
+				this.WCObject = new ApiV3WCObject( new RestAPI( this.Config.ShopUrl + ApiBasePath.V3, this.Config.ConsumerKey, this.Config.ConsumerSecret, authorizedHeader: false ), legacyApiWcObject );
 			else
 				this.WCObject = legacyApiWcObject;
 		}

--- a/src/WooCommerceAccess/Shared/WooCommerceApiVersionDetector.cs
+++ b/src/WooCommerceAccess/Shared/WooCommerceApiVersionDetector.cs
@@ -14,8 +14,8 @@ namespace WooCommerceAccess.Shared
 		private readonly string _shopUrl;
 		private readonly int _retryAttempts;
 		private readonly HttpClient _httpClient;
-		private const string JsonApiV3DescriptionUrl = "/wp-json/wc/v3/";
-		private const string ProductsLegacyApiV3Url = "/wc-api/v3/products";
+		private const string JsonApiV3DescriptionUrl = "/" + ApiBasePath.V3;
+		private const string ProductsLegacyApiV3Url = "/" + ApiBasePath.LegacyV3 + "/products";
 
 		public WooCommerceApiVersionDetector( string shopUrl, int retryAttempts, string userAgentHeader )
 		{

--- a/src/WooCommerceAccess/WooCommerceAccess.csproj
+++ b/src/WooCommerceAccess/WooCommerceAccess.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Polly" Version="7.2.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="WooCommerceNET.SV" Version="1.2.13" />
+    <PackageReference Include="WooCommerceNET.SV" Version="1.2.14-alpha.1" />
   </ItemGroup>
 
 </Project>

--- a/src/WooCommerceTests/Mappers/ResponseDeserialization/Legacy/OrderListDeserializationTests.cs
+++ b/src/WooCommerceTests/Mappers/ResponseDeserialization/Legacy/OrderListDeserializationTests.cs
@@ -1,0 +1,36 @@
+using System.Linq;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+using WooCommerceAccess.Services;
+using WooCommerceNET;
+using LegacyModels = WooCommerceNET.WooCommerce.Legacy;
+// ReSharper disable StringLiteralTypo
+
+namespace WooCommerceTests.Mappers.ResponseDeserialization.Legacy
+{
+	public class OrderListDeserializationTests
+	{
+		private readonly Randomizer _randomizer = new Randomizer();
+		private RestAPI _restApi;
+
+		[SetUp]
+		public void Init()
+		{
+			_restApi = new RestAPI(url: ApiBasePath.V3, key: _randomizer.GetString(), secret: _randomizer.GetString());
+		}
+
+		[Test]
+		[Description("This happens when WooCommerce AVATAX plug-in is used")]
+		public void DeserializeJSonOrderList_ShouldNotThrow_WhenOrderTaxLineContainsNonNumericRateId()
+		{
+			const string orderId = "5176";
+			const string nonNumericRateId = "AVATAX-TX-STATE-TAX";
+			var orderListRawJsonWithNonNumericTaxLineRateId = "[{\"id\":" + orderId + ",\"order_number\":\"5176\",\"order_key\":\"123\",\"created_at\":\"2022-10-19T19:33:05Z\",\"updated_at\":\"2022-10-19T19:33:12Z\",\"completed_at\":\"1970-01-01T00:00:00Z\",\"status\":\"processing\",\"currency\":\"USD\",\"total\":\"0.55\",\"subtotal\":\"0.50\",\"total_line_items_quantity\":1,\"total_tax\":\"0.05\",\"total_shipping\":\"0.00\",\"cart_tax\":\"0.05\",\"shipping_tax\":\"0.00\",\"total_discount\":\"0.00\",\"shipping_methods\":\"\",\"payment_details\":{\"method_id\":\"stripe\",\"method_title\":\"Credit card / debit card\",\"paid\":true},\"billing_address\":{\"first_name\":\"OmriTESTING SHIPSTATION SYNC\",\"last_name\":\"Tester\",\"company\":\"\",\"address_1\":\"123 Some St\",\"address_2\":\"\",\"city\":\"Austin\",\"state\":\"TX\",\"postcode\":\"78749\",\"country\":\"US\",\"email\":\"testFake@skuvault.com\",\"phone\":\"\"},\"shipping_address\":{\"first_name\":\"OmriTESTING SHIPSTATION SYNC\",\"last_name\":\"Tester\",\"company\":\"\",\"address_1\":\"123 Some St\",\"address_2\":\"\",\"city\":\"Austin\",\"state\":\"TX\",\"postcode\":\"78749\",\"country\":\"US\"},\"note\":\"\",\"customer_ip\":\"1.1.1.1\",\"customer_user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:105.0) Gecko/20100101 Firefox/105.0\",\"customer_id\":3,\"view_order_url\":\"https://www.somewhere.com\",\"line_items\":[{\"id\":89,\"subtotal\":\"0.50\",\"subtotal_tax\":\"0.05\",\"total\":\"0.50\",\"total_tax\":\"0.05\",\"price\":\"0.50\",\"quantity\":1,\"tax_class\":\"\",\"name\":\"The Paris Hours\",\"product_id\":4660,\"sku\":\"LQ127\",\"meta\":[]}],\"shipping_lines\":[],\"tax_lines\":[{\"id\":90,\"rate_id\":\"" + nonNumericRateId + "\",\"code\":\"AVATAX-TX-STATE-TAX\",\"title\":\"State Sales Tax\",\"total\":\"0.03\",\"compound\":false},{\"id\":91,\"rate_id\":\"AVATAX-TX-CITY-TAX\",\"code\":\"AVATAX-TX-CITY-TAX\",\"title\":\"City Sales Tax\",\"total\":\"0.01\",\"compound\":false},{\"id\":92,\"rate_id\":\"AVATAX-TX-SPECIAL-TAX\",\"code\":\"AVATAX-TX-SPECIAL-TAX\",\"title\":\"Special Sales Tax\",\"total\":\"0.01\",\"compound\":false}],\"fee_lines\":[],\"coupon_lines\":[],\"customer\":{\"id\":3,\"created_at\":\"2022-08-24T15:20:53Z\",\"last_update\":\"2022-10-19T19:33:05Z\",\"email\":\"testFake@skuvault.com\",\"first_name\":\"Omri\",\"last_name\":\"Tester\",\"username\":\"ob\",\"role\":\"administrator\",\"last_order_id\":5176,\"last_order_date\":\"2022-10-19T19:33:05Z\",\"orders_count\":2,\"total_spent\":\"1.10\",\"avatar_url\":\"https://secure.gravatar.com/avatar/1111\",\"billing_address\":{\"first_name\":\"OmriTESTING SHIPSTATION SYNC\",\"last_name\":\"Tester\",\"company\":\"\",\"address_1\":\"123 Some St\",\"address_2\":\"\",\"city\":\"Austin\",\"state\":\"TX\",\"postcode\":\"78749\",\"country\":\"US\",\"email\":\"testFake@skuvault.com\",\"phone\":\"\"},\"shipping_address\":{\"first_name\":\"OmriTESTING SHIPSTATION SYNC\",\"last_name\":\"Tester\",\"company\":\"\",\"address_1\":\"123 Some St\",\"address_2\":\"\",\"city\":\"Austin\",\"state\":\"TX\",\"postcode\":\"78749\",\"country\":\"US\"}}}]";
+
+			var result = _restApi.DeserializeJSon<LegacyModels.OrderList>(orderListRawJsonWithNonNumericTaxLineRateId);
+
+			var resultOrder = result.Single();
+			Assert.That(resultOrder.id, Is.EqualTo(orderId));
+		}
+	}
+}

--- a/src/WooCommerceTests/VariationTests.cs
+++ b/src/WooCommerceTests/VariationTests.cs
@@ -6,7 +6,6 @@ using FluentAssertions;
 using NUnit.Framework;
 using WooCommerceAccess.Models;
 using WooCommerceAccess.Services;
-using WooCommerceAccess.Shared;
 using WooCommerceNET;
 
 namespace WooCommerceTests
@@ -23,7 +22,7 @@ namespace WooCommerceTests
 		[ SetUp ]
 		public void Initialize()
 		{
-			this._serviceUrl = base.Config.ShopUrl + "wp-json/wc/v3/";
+			this._serviceUrl = base.Config.ShopUrl + ApiBasePath.V3;
 			this._apiV3WcObject = new ApiV3WCObject( new RestAPI( this._serviceUrl, base.Config.ConsumerKey, base.Config.ConsumerSecret ) );
 		}
 

--- a/src/WooCommerceTests/WooCommerceTests.csproj
+++ b/src/WooCommerceTests/WooCommerceTests.csproj
@@ -65,8 +65,9 @@
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="WooCommerce.NET, Version=1.2.13.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\WooCommerceNET.SV.1.2.13\lib\net48\WooCommerce.NET.dll</HintPath>
+    <Reference Include="WooCommerce.NET, Version=1.2.14.1, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\WooCommerceNET.SV.1.2.14-alpha.1\lib\net48\WooCommerce.NET.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -76,6 +77,7 @@
     <Compile Include="BatchListTests.cs" />
     <Compile Include="JsonSerializerTests.cs" />
     <Compile Include="Mappers\OrderMapperTests.cs" />
+    <Compile Include="Mappers\ResponseDeserialization\Legacy\OrderListDeserializationTests.cs" />
     <Compile Include="OrderTests.cs" />
     <Compile Include="Mappers\ProductMapperTests.cs" />
     <Compile Include="ProductTests.cs" />

--- a/src/WooCommerceTests/packages.config
+++ b/src/WooCommerceTests/packages.config
@@ -6,5 +6,5 @@
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.0" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
-  <package id="WooCommerceNET.SV" version="1.2.13" targetFramework="net48" />
+  <package id="WooCommerceNET.SV" version="1.2.14-alpha.1" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
[GUARD-2572]

- Point to updated WooCommerce.NET.SV package ([PR](https://github.com/skuvault-integrations/WooCommerce.NET/pull/18)) with the non-numeric TaxLine.rate_id fix.
  - Currently, this points to a local WooCommerce.NET.SV package. Will be published once approved and merged into the trunk.
- Add test for the TaxLine.rate_id fix
- Extract the ApiBasePath from strings into a combined constant
- Add SkuVault PR template