### PR TITLE
VT-6153 WooCommerce Full Inventory sync is failing

### DIFF
--- a/src/WooCommerceAccess/Models/Variation.cs
+++ b/src/WooCommerceAccess/Models/Variation.cs
@@ -51,6 +51,18 @@ namespace WooCommerceAccess.Models
 				images.Add( variationV3.image.src );
 			}
 
+			var attributes = new Dictionary<string, string>();
+			if (variationV3.attributes != null)
+			{
+				foreach (var attribute in variationV3.attributes)
+				{
+					if (!string.IsNullOrWhiteSpace(attribute.name) && !attributes.ContainsKey(attribute.name))
+					{
+						attributes.Add(attribute.name, attribute.option);
+					}
+				}
+			}
+
 			return new WooCommerceVariation
 			{
 				Id = variationV3.id,
@@ -62,8 +74,7 @@ namespace WooCommerceAccess.Models
 				Weight = variationV3.weight,
 				SalePrice = variationV3.sale_price,
 				RegularPrice = variationV3.regular_price,
-				Attributes = variationV3.attributes?.Where( a => !string.IsNullOrWhiteSpace( a.name ) )
-					.ToDictionary( a => a.name, a => a.option ),
+				Attributes = attributes,
 				UpdatedDateUtc = variationV3.date_modified_gmt,
 				CreatedDateUtc = variationV3.date_created_gmt,
 				ManagingStock = (bool?) variationV3.manage_stock

--- a/src/WooCommerceAccess/WooCommerceAccess.csproj
+++ b/src/WooCommerceAccess/WooCommerceAccess.csproj
@@ -9,13 +9,13 @@
     <PackageLicenseUrl>https://github.com/skuvault/wooCommerceAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/wooCommerceAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault-integrations/wooCommerceAccess.git</RepositoryUrl>
-    <Version>1.7.3</Version>
+    <Version>1.7.4-alpha.1</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.7.3.0</AssemblyVersion>
-    <FileVersion>1.7.3.0</FileVersion>
+    <AssemblyVersion>1.7.4.1</AssemblyVersion>
+    <FileVersion>1.7.4.1</FileVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <RepositoryType>git</RepositoryType>
-    <PackageVersion>1.7.3</PackageVersion>
+    <PackageVersion>1.7.4-alpha.1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WooCommerceTests/Mappers/VariationMappersTests.cs
+++ b/src/WooCommerceTests/Mappers/VariationMappersTests.cs
@@ -121,5 +121,47 @@ namespace WooCommerceTests
 			Assert.AreEqual( variation.manage_stock, svVariation.ManagingStock );
 			Assert.AreEqual( variation.description, svVariation.Description );
 		}
+
+		[Test]
+		public void ToSvVariation_FirstAttributeIsUsed_WhenPassedAttributesWithTheSameNames()
+		{
+			// Arrange
+			var variation = new WooCommerceNET.WooCommerce.v3.Variation
+			{
+				id = 3,
+				sku = "somesku",
+				attributes = new List<VariationAttribute>
+				{
+					new VariationAttribute
+					{
+						name = "size",
+						option = "small"
+					},
+					new VariationAttribute
+					{
+						name = "size",
+						option = "big"
+					},
+					new VariationAttribute
+					{
+						name = "color",
+						option = "blue"
+					}
+				}
+			};
+
+			// Act
+			var svVariation = variation.ToSvVariation();
+
+			// Assert
+			var svVariationAttributes = svVariation.Attributes.ToArray();
+			Assert.AreEqual(variation.id, svVariation.Id);
+			Assert.AreEqual(variation.sku, svVariation.Sku);
+			Assert.AreEqual(2, svVariationAttributes.Length);
+			Assert.AreEqual(variation.attributes[0].name, svVariationAttributes[0].Key);
+			Assert.AreEqual(variation.attributes[0].option, svVariationAttributes[0].Value);
+			Assert.AreEqual(variation.attributes[2].name, svVariationAttributes[1].Key);
+			Assert.AreEqual(variation.attributes[2].option, svVariationAttributes[1].Value);
+		}
 	}
 }


### PR DESCRIPTION
# Description

Tickets: [VT-6153] <!-- Replace with appropriate tickets. Some automation depend on this section, don't remove -->

## Background

We get variants with the same attribute names from WooCommerce and as result we get _**An item with the same key has already been added.**_ 

## About these changes

Implemented logic to skip attribute duplicates

# PR Readiness Checklist

<!-- Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it. -->

- [ ] I have updated all relevant configuration
- [x] Followed [development conventions][1] to the best of my ability
- [x] Code is documented, particularly public interfaces and hard-to-understand areas
- [x] Tests are updated / added and all pass
- [x] Performed a self-review of my own code
- [ ] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [x] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions


[VT-6153]: https://agileharbor.atlassian.net/browse/VT-6153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ