### PR TITLE
VT-6192 WooCommerce: Error on The Full Inventory Sync

### DIFF
--- a/src/WooCommerceAccess/WooCommerceAccess.csproj
+++ b/src/WooCommerceAccess/WooCommerceAccess.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Polly" Version="7.2.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="WooCommerceNET.SV" Version="1.2.15" />
+    <PackageReference Include="WooCommerceNET.SV" Version="1.2.16" />
   </ItemGroup>
 
 </Project>

--- a/src/WooCommerceTests/Mappers/ProductMapperTests.cs
+++ b/src/WooCommerceTests/Mappers/ProductMapperTests.cs
@@ -72,8 +72,8 @@ namespace WooCommerceTests
 					1,
 					2
 				},
-				date_created_gmt = new DateTime( 2099, 1, 1 ),
-				date_modified_gmt = new DateTime( 2099, 11, 11 )
+				date_created_gmt_value = "2099/01/01",
+				date_modified_gmt_value = "2099/11/11"
 			};
 
 			var svProduct = product.ToSvProduct();
@@ -91,7 +91,7 @@ namespace WooCommerceTests
 			Assert.AreEqual( product.weight, svProduct.Weight );
 			Assert.AreEqual( product.sale_price, svProduct.SalePrice );
 			Assert.AreEqual( product.regular_price, svProduct.RegularPrice );
-			Assert.AreEqual( 1, svProduct.Attributes.Count );
+			Assert.AreEqual( 2, svProduct.Attributes.Count );
 			Assert.AreEqual( product.attributes[0].name, svProduct.Attributes.First().Key );
 			Assert.AreEqual( product.attributes[0].options.First(), svProduct.Attributes.First().Value );
 			Assert.AreEqual( product.variations.Any(), svProduct.HasVariations );
@@ -180,7 +180,7 @@ namespace WooCommerceTests
 			Assert.AreEqual( decimal.Parse( legacyProduct.weight ) , svProduct.Weight );
 			Assert.AreEqual( legacyProduct.sale_price , svProduct.SalePrice );
 			Assert.AreEqual( legacyProduct.regular_price , svProduct.RegularPrice );
-			Assert.AreEqual( 1 , svProduct.Attributes.Count );
+			Assert.AreEqual( 2 , svProduct.Attributes.Count );
 			Assert.AreEqual( legacyProduct.attributes[0].name , svProduct.Attributes.First().Key );
 			Assert.AreEqual( legacyProduct.attributes[0].options.First() , svProduct.Attributes.First().Value );
 			Assert.AreEqual( legacyProduct.variations.Any() , svProduct.Variations.Any() );

--- a/src/WooCommerceTests/WooCommerceTests.csproj
+++ b/src/WooCommerceTests/WooCommerceTests.csproj
@@ -65,9 +65,8 @@
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="WooCommerce.NET, Version=1.2.14.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\WooCommerceNET.SV.1.2.14\lib\net48\WooCommerce.NET.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="WooCommerce.NET, Version=1.2.16.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\WooCommerceNET.SV.1.2.16\lib\net48\WooCommerce.NET.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/WooCommerceTests/packages.config
+++ b/src/WooCommerceTests/packages.config
@@ -6,5 +6,5 @@
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.0" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
-  <package id="WooCommerceNET.SV" version="1.2.14" targetFramework="net48" />
+  <package id="WooCommerceNET.SV" version="1.2.16" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
# Description

Tickets: [VT-6192]

- Updated package for WooCommerce.Net (this is goal of this ticket)
- I didn't update WooCommerce.Net for WooCommerceTests in previous ticket so I did it in this PR (before new version)
- Some tests were fail so I fixed them.

# PR Readiness Checklist

- [X] I have updated all relevant configuration
- [X] Followed [development conventions][1] to the best of my ability
- [X] Code is documented, particularly public interfaces and hard-to-understand areas
- [X] Tests are updated / added and all pass
- [X] Performed a self-review of my own code
- [X] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
- [X] Confluence documentation is updated, if needed
- [X] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions


[VT-6192]: https://agileharbor.atlassian.net/browse/VT-6192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ