### PR TITLE
GUARD-3571 [2] Sync-Correct-SaleNumber-and-Fields-that-Were-Pulled-as-Nulls

### DIFF
--- a/src/WooCommerceAccess/WooCommerceAccess.csproj
+++ b/src/WooCommerceAccess/WooCommerceAccess.csproj
@@ -9,13 +9,13 @@
     <PackageLicenseUrl>https://github.com/skuvault/wooCommerceAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/wooCommerceAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault-integrations/wooCommerceAccess.git</RepositoryUrl>
-    <Version>1.11.1</Version>
+    <Version>1.11.2</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.11.1.0</AssemblyVersion>
-    <FileVersion>1.11.1.0</FileVersion>
+    <AssemblyVersion>1.11.2.0</AssemblyVersion>
+    <FileVersion>1.11.2.0</FileVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <RepositoryType>git</RepositoryType>
-    <PackageVersion>1.11.1-alpha.1</PackageVersion>
+    <PackageVersion>1.11.2-alpha.1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WooCommerceTests/Mappers/OrderMapperTests.cs
+++ b/src/WooCommerceTests/Mappers/OrderMapperTests.cs
@@ -1,0 +1,214 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+using WooCommerceAccess.Models;
+using WooCommerceNET.WooCommerce.v2;
+using Order = WooCommerceNET.WooCommerce.v3.Order;
+
+namespace WooCommerceTests.Mappers
+{
+	public class OrderMapperTests
+	{
+		private static readonly Randomizer _randomizer = new Randomizer();
+		
+		[ Test ]
+		public void ToSvOrder_ShouldMapFieldsCorrectly_WhenPopulatedWithStandardValues()
+		{
+			var order = CreateWooCommerceOrder();
+
+			var result = order.ToSvOrder();
+
+			Assert.Multiple(() =>
+			{
+				Assert.That( result.Id, Is.EqualTo( order.id ));
+				Assert.That( result.Number, Is.EqualTo( order.number ) );
+				AssertBuyerInfoMapped( result.BuyerInfo, order.billing );
+				AssertLineItemsMapped( result.Items.Single(), order.line_items.Single() );
+				AssertOrderAmountsMapped( result, order );
+				AssertCouponLinesMapped( result.Coupons.Single(), order.coupon_lines.Single() );
+				Assert.That( result.Currency, Is.EqualTo( order.currency ));
+				Assert.That( result.Note, Is.EqualTo( order.customer_note ));
+				AssertDatesMapped( result, order );
+				AssertShippingAddressMapped( result.ShippingAddress, order.shipping );
+				Assert.That( result.ShippingInfo.Common, Is.EqualTo( order.shipping_lines[ 0 ].method_title + "," + order.shipping_lines[ 1 ].method_title ) );
+			} );
+		}
+
+		[ Test ]
+		public void ToSvOrder_ReturnsWasPaidFalse_WhenPaidDateIsNull()
+		{
+			var order = CreateWooCommerceOrder();
+			order.date_paid_gmt = null;
+
+			var result = order.ToSvOrder();
+
+			Assert.IsFalse( result.WasPaid );
+		}
+		
+		[ Test ]
+		public void ToSvOrder_ShouldDefaultNullOptionalFields()
+		{
+			var order = CreateWooCommerceOrder();
+			order.total = null;
+			order.total_tax = null;
+			order.discount_total = null;
+			order.line_items[ 0 ].id = null;
+			order.line_items[ 0 ].product_id = null;
+			order.line_items[ 0 ].total_tax = null;
+			
+			//Act
+			var result = order.ToSvOrder();
+			
+			Assert.Multiple(() =>
+			{
+				Assert.That( result.Total, Is.EqualTo( default( decimal ) ) );
+				Assert.That( result.TotalTax, Is.EqualTo( default( decimal ) ) );
+				Assert.That( result.TotalDiscount, Is.EqualTo( default( decimal ) ) );
+				var resultFirstLineItem = result.Items.Single();
+				Assert.That( resultFirstLineItem.Id, Is.EqualTo( default( int ) ) );
+				Assert.That( resultFirstLineItem.ProductId, Is.EqualTo( default( int ) ) );
+				Assert.That( resultFirstLineItem.TotalTax, Is.EqualTo( default( decimal ) ) );
+			} );
+		}
+		
+		[ Test ]
+		public void ToSvOrder_ShouldThrow_WhenLineItemQuantityIsNull()
+		{
+			var order = CreateWooCommerceOrder();
+			order.line_items[ 0 ].quantity = null;
+			
+			// Act
+			// Assert
+			Assert.Throws< Exception >(() => order.ToSvOrder());
+		}
+
+		[ Test ]
+		public void ToSvOrder_ShouldThrow_WhenLineItemPriceIsNull()
+		{
+			var order = CreateWooCommerceOrder();
+			order.line_items[ 0 ].price = null;
+			
+			// Act
+			// Assert
+			Assert.Throws< Exception >(() => order.ToSvOrder());
+		}
+
+		private static Order CreateWooCommerceOrder()
+		{
+			return new Order
+			{
+				id = _randomizer.GetString(),
+				number = _randomizer.GetString(),
+				billing = new OrderBilling
+				{
+					company = _randomizer.GetString(),
+					first_name = _randomizer.GetString(),
+					last_name = _randomizer.GetString(),
+					email = _randomizer.GetString(),
+					phone = _randomizer.GetString()
+				},
+				line_items = new List<OrderLineItem>
+				{
+					new OrderLineItem
+					{
+						id = ( int )_randomizer.NextUInt(),
+						product_id = ( int )_randomizer.NextUInt(),
+						sku = _randomizer.GetString(),
+						quantity = ( int )_randomizer.NextUInt(),
+						price = ( int )_randomizer.NextUInt(),
+						total_tax = ( int )_randomizer.NextUInt()
+					}
+				},
+				coupon_lines = new List<OrderCouponLine>
+				{
+					new OrderCouponLine
+					{
+						code = _randomizer.GetString(),
+						discount = _randomizer.NextDecimal()
+					}
+				},
+				currency = _randomizer.GetString(),
+				customer_note = _randomizer.GetString(),
+				date_created_gmt = DateTime.UtcNow,
+				date_modified_gmt = DateTime.UtcNow.AddMinutes( _randomizer.Next( 1, 10 ) ),
+				date_paid_gmt = DateTime.UtcNow.AddMinutes( _randomizer.Next( 11, 20 ) ),
+				total = _randomizer.NextDecimal(),
+				total_tax = _randomizer.NextDecimal(),
+				discount_total = _randomizer.NextDecimal(),
+				shipping = new OrderShipping
+				{
+					address_1 = _randomizer.GetString(),
+					address_2 = _randomizer.GetString(),
+					city = _randomizer.GetString(),
+					country = _randomizer.GetString(),
+					postcode = _randomizer.GetString(),
+					state = _randomizer.GetString()
+				},
+				shipping_lines = new List<OrderShippingLine>
+				{
+					new OrderShippingLine
+					{
+						method_title = _randomizer.GetString()
+					},
+					new OrderShippingLine
+					{
+						method_title = _randomizer.GetString()
+					}
+				}
+			};
+		}
+
+		private static void AssertBuyerInfoMapped( WooCommerceBuyerInfo resultBuyerInfo, OrderBilling orderBilling )
+		{
+			Assert.That( resultBuyerInfo.Company, Is.EqualTo( orderBilling.company ) );
+			Assert.That( resultBuyerInfo.FirstName, Is.EqualTo( orderBilling.first_name ) );
+			Assert.That( resultBuyerInfo.LastName, Is.EqualTo( orderBilling.last_name ) );
+			Assert.That( resultBuyerInfo.Email, Is.EqualTo( orderBilling.email ) );
+			Assert.That( resultBuyerInfo.Phone, Is.EqualTo( orderBilling.phone ) );
+		}
+
+		private static void AssertLineItemsMapped( WooCommerceOrderItem resultFirstLineItem, OrderLineItem orderFirstLineItem )
+		{
+			Assert.That( resultFirstLineItem.Id, Is.EqualTo( orderFirstLineItem.id ) );
+			Assert.That( resultFirstLineItem.ProductId, Is.EqualTo( orderFirstLineItem.product_id ) );
+			Assert.That( resultFirstLineItem.Sku, Is.EqualTo( orderFirstLineItem.sku ) );
+			Assert.That( resultFirstLineItem.Quantity, Is.EqualTo( orderFirstLineItem.quantity ) );
+			Assert.That( resultFirstLineItem.Price, Is.EqualTo( orderFirstLineItem.price ) );
+			Assert.That( resultFirstLineItem.TotalTax, Is.EqualTo( orderFirstLineItem.total_tax ) );
+		}
+
+		private static void AssertOrderAmountsMapped( WooCommerceOrder result, Order order )
+		{
+			Assert.That( result.TotalTax, Is.EqualTo( order.total_tax ) );
+			Assert.That( result.Total, Is.EqualTo( order.total ) );
+			Assert.That( result.TotalDiscount, Is.EqualTo( order.discount_total ) );
+		}
+
+		private static void AssertCouponLinesMapped( WooCommerceCouponLine resultFirstCouponLine,
+			OrderCouponLine orderFirstCouponLine )
+		{
+			Assert.That( resultFirstCouponLine.Code, Is.EqualTo( orderFirstCouponLine.code ) );
+			Assert.That( resultFirstCouponLine.Amount, Is.EqualTo( orderFirstCouponLine.discount ) );
+		}
+
+		private static void AssertDatesMapped( WooCommerceOrder result, Order order )
+		{
+			Assert.That( result.CreateDateUtc, Is.EqualTo( order.date_created_gmt ) );
+			Assert.That( result.UpdateDateUtc, Is.EqualTo( order.date_modified_gmt ) );
+			Assert.That( result.PaidDateUtc, Is.EqualTo( order.date_paid_gmt ) );
+			Assert.That( result.WasPaid, Is.EqualTo( order.date_paid_gmt != null ) );
+		}
+		
+		private static void AssertShippingAddressMapped( WooCommerceShippingAddress resultShippingAddress, OrderShipping orderShipping )
+		{
+			Assert.That( resultShippingAddress.AddressLine, Is.EqualTo( orderShipping.address_1 ) );
+			Assert.That( resultShippingAddress.AddressLine2, Is.EqualTo( orderShipping.address_2 ) );
+			Assert.That( resultShippingAddress.City, Is.EqualTo( orderShipping.city ) );
+			Assert.That( resultShippingAddress.CountryCode, Is.EqualTo( orderShipping.country ) );
+			Assert.That( resultShippingAddress.PostCode, Is.EqualTo( orderShipping.postcode ) );
+			Assert.That( resultShippingAddress.State, Is.EqualTo( orderShipping.state ) );
+		}
+	}
+}

--- a/src/WooCommerceTests/WooCommerceTests.csproj
+++ b/src/WooCommerceTests/WooCommerceTests.csproj
@@ -74,6 +74,7 @@
     <Compile Include="BaseTest.cs" />
     <Compile Include="ApiDetectorTests.cs" />
     <Compile Include="BatchListTests.cs" />
+    <Compile Include="Mappers\OrderMapperTests.cs" />
     <Compile Include="SettingsServiceTests.cs" />
     <Compile Include="WCObjectBaseTests.cs" />
     <Compile Include="JsonSerializerTests.cs" />


### PR DESCRIPTION
[GUARD-3571]

Summary: Correctly map WooCommerce REST API order fields to pull the same fields into SkuVault as we did with legacy earlier.

#### Background
In this ticket's [previous PR](https://github.com/skuvault-integrations/wooCommerceAccess/pull/59), calls to the legacy API were removed. This required adding a call to the non-legacy ("REST") API to get orders. Felix has noticed that the SV saleId is in different format after calling the non-legacy WooCommerce endpoint.

#### About these changes
- Order.ToSvOrder(): map SV order number from WooCommerce order number, so that we continue to save the same type of value into Skuvault order as before WooCommerce legacy was phased out.
- Correctly map other order fields. On null, default or throw (when mandatory).
- Add order mapper tests.

### PR Readiness Checklist

- [x] I have updated all relevant configuration
- [x] Followed [development conventions][1] to the best of my ability
- [x] Code is documented, particularly public interfaces and hard-to-understand areas
- [x] Tests are updated / added and all pass
- [x] Performed a self-review of my own code
- [ ] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [x] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions


[GUARD-3571]: https://linnworks.atlassian.net/browse/GUARD-3571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ