### PR TITLE
GUARD-3571 Remove -alpha from package version

### DIFF
--- a/src/WooCommerceAccess/WooCommerceAccess.csproj
+++ b/src/WooCommerceAccess/WooCommerceAccess.csproj
@@ -15,7 +15,7 @@
     <FileVersion>1.11.2.0</FileVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <RepositoryType>git</RepositoryType>
-    <PackageVersion>1.11.2-alpha.1</PackageVersion>
+    <PackageVersion>1.11.2</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
[GUARD-3571]

Summary: Remove -alpha from package version.

#### Background
Want to indicate that this is a stable version, tested in QA.

#### About these changes
Remove -alpha from package version

### PR Readiness Checklist

<!-- Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it. -->

- [x] I have updated all relevant configuration
- [x] Followed [development conventions][1] to the best of my ability
- [x] Code is documented, particularly public interfaces and hard-to-understand areas
- [ ] Tests are updated / added and all pass
- [x] Performed a self-review of my own code
- [ ] Acceptance criteria are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [x] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions


[GUARD-3571]: https://linnworks.atlassian.net/browse/GUARD-3571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ