### PR TITLE
GUARD-3571 Orders Async Fix

### DIFF
--- a/src/WooCommerceAccess/ApiServices/OrdersApiService.cs
+++ b/src/WooCommerceAccess/ApiServices/OrdersApiService.cs
@@ -42,7 +42,7 @@ namespace WooCommerceAccess.ApiServices
 				{ dateFilterAfter, startDateUtc.ToString( "o" ) },
 				{ dateFilterBefore, endDateUtc.ToString( "o" ) }
 			};
-			return await this.CollectOrdersFromAllPagesAsync( orderFilters, pageSize, url, mark );
+			return await this.CollectOrdersFromAllPagesAsync( orderFilters, pageSize, url, mark ).ConfigureAwait( false );
 		}
 
 		private async Task<IEnumerable<WooCommerceOrder>> CollectOrdersFromAllPagesAsync(Dictionary<string, string> orderFilters,

--- a/src/WooCommerceAccess/Services/Orders/WooCommerceOrdersService.cs
+++ b/src/WooCommerceAccess/Services/Orders/WooCommerceOrdersService.cs
@@ -21,11 +21,11 @@ namespace WooCommerceAccess.Services.Orders
 			this._ordersApiUrl = base.WCObject.WooCommerceNetObjectV3.Order.API.Url + base.WCObject.WooCommerceNetObjectV3.Order.APIEndpoint;
 		}
 
-		public Task< IEnumerable< WooCommerceOrder > > GetOrdersAsync( DateTime startDateUtc, DateTime endDateUtc, Mark mark )
+		public async Task< IEnumerable< WooCommerceOrder > > GetOrdersAsync( DateTime startDateUtc, DateTime endDateUtc, Mark mark )
 		{
-			return base.SendRequestAsync< IEnumerable< WooCommerceOrder > >( this._ordersApiUrl, mark, ( url, marker ) =>
+			return await base.SendRequestAsync< IEnumerable< WooCommerceOrder > >( this._ordersApiUrl, mark, async ( url, marker ) =>
 			{
-				return this._ordersApiService.GetOrdersAsync( startDateUtc, endDateUtc, base.Config.OrdersPageSize, url, marker );
+				return await  this._ordersApiService.GetOrdersAsync( startDateUtc, endDateUtc, base.Config.OrdersPageSize, url, marker );
 			} );
 		}
 	}

--- a/src/WooCommerceAccess/Services/Orders/WooCommerceOrdersService.cs
+++ b/src/WooCommerceAccess/Services/Orders/WooCommerceOrdersService.cs
@@ -25,8 +25,8 @@ namespace WooCommerceAccess.Services.Orders
 		{
 			return await base.SendRequestAsync< IEnumerable< WooCommerceOrder > >( this._ordersApiUrl, mark, async ( url, marker ) =>
 			{
-				return await  this._ordersApiService.GetOrdersAsync( startDateUtc, endDateUtc, base.Config.OrdersPageSize, url, marker );
-			} );
+				return await  this._ordersApiService.GetOrdersAsync( startDateUtc, endDateUtc, base.Config.OrdersPageSize, url, marker ).ConfigureAwait( false );
+			} ).ConfigureAwait( false );
 		}
 	}
 }

--- a/src/WooCommerceAccess/WooCommerceAccess.csproj
+++ b/src/WooCommerceAccess/WooCommerceAccess.csproj
@@ -9,13 +9,13 @@
     <PackageLicenseUrl>https://github.com/skuvault/wooCommerceAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/wooCommerceAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault-integrations/wooCommerceAccess.git</RepositoryUrl>
-    <Version>1.11.3</Version>
+    <Version>1.11.4</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.11.3.0</AssemblyVersion>
-    <FileVersion>1.11.3.0</FileVersion>
+    <AssemblyVersion>1.11.4.0</AssemblyVersion>
+    <FileVersion>1.11.4.0</FileVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <RepositoryType>git</RepositoryType>
-    <PackageVersion>1.11.3</PackageVersion>
+    <PackageVersion>1.11.4</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WooCommerceAccess/WooCommerceAccess.csproj
+++ b/src/WooCommerceAccess/WooCommerceAccess.csproj
@@ -5,17 +5,17 @@
     <Authors>SkuVault</Authors>
     <Company>SkuVault</Company>
     <Description>WooCommerce webservices API wrapper</Description>
-    <Copyright>SkuVault © 2021-2023</Copyright>
+    <Copyright>SkuVault © 2021-2024</Copyright>
     <PackageLicenseUrl>https://github.com/skuvault/wooCommerceAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/wooCommerceAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault-integrations/wooCommerceAccess.git</RepositoryUrl>
-    <Version>1.11.2</Version>
+    <Version>1.11.3</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.11.2.0</AssemblyVersion>
-    <FileVersion>1.11.2.0</FileVersion>
+    <AssemblyVersion>1.11.3.0</AssemblyVersion>
+    <FileVersion>1.11.3.0</FileVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <RepositoryType>git</RepositoryType>
-    <PackageVersion>1.11.2</PackageVersion>
+    <PackageVersion>1.11.3</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
[GUARD-3571]

Summary: `Await` calls to the orders-related `async` methods. Otherwise, v1 channel account spins indefinitely on credentials validation (tries to get orders).

#### Background
New methods were added for the non-legacy WooCommerce API to get orders. But they were not called as `async` all the way through. This didn't impact the syncs, but broke Channel Accounts page credentials validation (see [comment](https://linnworks.atlassian.net/browse/RLS-4986?focusedCommentId=212160)).

#### About these changes
See summary.

### PR Readiness Checklist

<!-- Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it. -->

- [x] I have updated all relevant configuration
- [x] Followed [development conventions][1] to the best of my ability
- [x] Code is documented, particularly public interfaces and hard-to-understand areas
- [ ] Tests are updated / added and all pass
- [x] Performed a self-review of my own code
- [x] Acceptance criteria are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [x] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions


[GUARD-3571]: https://linnworks.atlassian.net/browse/GUARD-3571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ