### PR TITLE
PBL-9276 Orders Missed When Filtered by UTC Date/Time

### DIFF
--- a/src/WooCommerceAccess/ApiServices/OrdersApiService.cs
+++ b/src/WooCommerceAccess/ApiServices/OrdersApiService.cs
@@ -44,6 +44,7 @@ namespace WooCommerceAccess.ApiServices
 				{ dateFilterAfter, startDateUtc.RoundDateDownToTopOfMinute().ToString( "s" ) },
 				{ dateFilterBefore, endDateUtc.RoundDateUpToTopOfMinute().ToString( "s" ) }
 			};
+			//TODO PBL-9276 Unit test this new logic. Prob. makes sense to extract the entire orderFilters building logic into a helper method somewhere, so that it's testable and modular.
 			if ( startDateUtc.Kind == DateTimeKind.Utc && endDateUtc.Kind == DateTimeKind.Utc )
 			{
 				orderFilters.Add( "dates_are_gmt", "1" );

--- a/src/WooCommerceAccess/ApiServices/OrdersApiService.cs
+++ b/src/WooCommerceAccess/ApiServices/OrdersApiService.cs
@@ -40,9 +40,14 @@ namespace WooCommerceAccess.ApiServices
 			const string dateFilterBefore = "modified_before";
 			var orderFilters = new Dictionary< string, string >
 			{
-				{ dateFilterAfter, startDateUtc.RoundDateDownToTopOfMinute().ToString( "o" ) },
-				{ dateFilterBefore, endDateUtc.RoundDateUpToTopOfMinute().ToString( "o" ) }
+				//Sortable "s" format: https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#the-sortable-s-format-specifier
+				{ dateFilterAfter, startDateUtc.RoundDateDownToTopOfMinute().ToString( "s" ) },
+				{ dateFilterBefore, endDateUtc.RoundDateUpToTopOfMinute().ToString( "s" ) }
 			};
+			if ( startDateUtc.Kind == DateTimeKind.Utc && endDateUtc.Kind == DateTimeKind.Utc )
+			{
+				orderFilters.Add( "dates_are_gmt", "1" );
+			}
 			return await this.CollectOrdersFromAllPagesAsync( orderFilters, pageSize, url, mark ).ConfigureAwait( false );
 		}
 

--- a/src/WooCommerceAccess/ApiServices/OrdersApiService.cs
+++ b/src/WooCommerceAccess/ApiServices/OrdersApiService.cs
@@ -36,19 +36,7 @@ namespace WooCommerceAccess.ApiServices
 		
 		public async Task< IEnumerable< WooCommerceOrder > > GetOrdersAsync( DateTime startDateUtc, DateTime endDateUtc, int pageSize, string url, Mark mark )
 		{
-			const string dateFilterAfter = "modified_after";
-			const string dateFilterBefore = "modified_before";
-			var orderFilters = new Dictionary< string, string >
-			{
-				//Sortable "s" format: https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#the-sortable-s-format-specifier
-				{ dateFilterAfter, startDateUtc.RoundDateDownToTopOfMinute().ToString( "s" ) },
-				{ dateFilterBefore, endDateUtc.RoundDateUpToTopOfMinute().ToString( "s" ) }
-			};
-			//TODO PBL-9276 Unit test this new logic. Prob. makes sense to extract the entire orderFilters building logic into a helper method somewhere, so that it's testable and modular.
-			if ( startDateUtc.Kind == DateTimeKind.Utc && endDateUtc.Kind == DateTimeKind.Utc )
-			{
-				orderFilters.Add( "dates_are_gmt", "1" );
-			}
+			var orderFilters = OrdersFiltersBuilder.CreateModifiedDateRangeFilters(startDateUtc, endDateUtc);
 			return await this.CollectOrdersFromAllPagesAsync( orderFilters, pageSize, url, mark ).ConfigureAwait( false );
 		}
 

--- a/src/WooCommerceAccess/Helpers/OrdersFiltersBuilder.cs
+++ b/src/WooCommerceAccess/Helpers/OrdersFiltersBuilder.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace WooCommerceAccess.Helpers
+{
+    public static class OrdersFiltersBuilder
+    {
+        public const string DatesAreGmt = "dates_are_gmt";
+        
+        public static Dictionary<string, string> CreateModifiedDateRangeFilters( DateTime startDate, DateTime endDate )
+        {
+            const string dateFilterAfter = "modified_after";
+            const string dateFilterBefore = "modified_before";
+            var orderFilters = new Dictionary< string, string >
+            {
+                //Sortable "s" format: https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#the-sortable-s-format-specifier
+                { dateFilterAfter, startDate.RoundDateDownToTopOfMinute().ToString( "s" ) },
+                { dateFilterBefore, endDate.RoundDateUpToTopOfMinute().ToString( "s" ) }
+            };
+            if ( startDate.Kind == DateTimeKind.Utc && endDate.Kind == DateTimeKind.Utc )
+            {
+                orderFilters.Add( DatesAreGmt, "1" );
+            }
+
+            return orderFilters;
+        }
+    }
+}

--- a/src/WooCommerceAccess/WooCommerceAccess.csproj
+++ b/src/WooCommerceAccess/WooCommerceAccess.csproj
@@ -9,13 +9,13 @@
     <PackageLicenseUrl>https://github.com/skuvault/wooCommerceAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/wooCommerceAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault-integrations/wooCommerceAccess.git</RepositoryUrl>
-    <Version>1.11.7</Version>
+    <Version>1.11.8</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.11.7.0</AssemblyVersion>
-    <FileVersion>1.11.7.0</FileVersion>
+    <AssemblyVersion>1.11.8.0</AssemblyVersion>
+    <FileVersion>1.11.8.0</FileVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <RepositoryType>git</RepositoryType>
-    <PackageVersion>1.11.7-alpha.1</PackageVersion>
+    <PackageVersion>1.11.8-alpha.1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WooCommerceAccess/WooCommerceAccess.csproj
+++ b/src/WooCommerceAccess/WooCommerceAccess.csproj
@@ -9,13 +9,13 @@
     <PackageLicenseUrl>https://github.com/skuvault/wooCommerceAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/wooCommerceAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault-integrations/wooCommerceAccess.git</RepositoryUrl>
-    <Version>1.11.6</Version>
+    <Version>1.11.7</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.11.6.0</AssemblyVersion>
-    <FileVersion>1.11.6.0</FileVersion>
+    <AssemblyVersion>1.11.7.0</AssemblyVersion>
+    <FileVersion>1.11.7.0</FileVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <RepositoryType>git</RepositoryType>
-    <PackageVersion>1.11.6</PackageVersion>
+    <PackageVersion>1.11.7-alpha.1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WooCommerceTests/Helpers/OrdersFiltersBuilderTests.cs
+++ b/src/WooCommerceTests/Helpers/OrdersFiltersBuilderTests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using NUnit.Framework;
+using WooCommerceAccess.Helpers;
+
+namespace WooCommerceTests.Helpers
+{
+    public class OrdersFiltersBuilderTests
+    {
+        [ Test ]
+        public void CreateModifiedDateRangeFilters_ShouldSetDatesAreGmtToTrue_WhenBothDatesAreUtc()
+        {
+            var startDate = new DateTime(2001, 1, 1, 1, 1, 1, DateTimeKind.Utc);
+            var endDate = new DateTime(2001, 1, 1, 1, 1, 1, DateTimeKind.Utc);
+            
+            var result = OrdersFiltersBuilder.CreateModifiedDateRangeFilters(startDate, endDate);
+            
+            Assert.That( result[OrdersFiltersBuilder.DatesAreGmt], Is.EqualTo( "1" ) );
+        }
+        
+        [ TestCase( DateTimeKind.Utc, DateTimeKind.Unspecified ) ]
+        [ TestCase( DateTimeKind.Unspecified, DateTimeKind.Utc ) ]
+        [ TestCase( DateTimeKind.Unspecified, DateTimeKind.Unspecified ) ]
+        [ TestCase( DateTimeKind.Utc, DateTimeKind.Local ) ]
+        [ TestCase( DateTimeKind.Local, DateTimeKind.Utc ) ]
+        [ TestCase( DateTimeKind.Local, DateTimeKind.Local ) ]
+        public void CreateModifiedDateRangeFilters_ShouldNotSetDatesAreGmtToTrue_WhenOneDateIsNotUtc( DateTimeKind startDateKind, DateTimeKind endDateKind )
+        {
+            var startDate = new DateTime(2001, 1, 1, 1, 1, 1, startDateKind);
+            var endDate = new DateTime(2001, 1, 1, 1, 1, 1, endDateKind);
+            
+            var result = OrdersFiltersBuilder.CreateModifiedDateRangeFilters(startDate, endDate);
+            
+            Assert.That( result.ContainsKey( OrdersFiltersBuilder.DatesAreGmt ), Is.False );
+        }
+    }
+}

--- a/src/WooCommerceTests/WooCommerceTests.csproj
+++ b/src/WooCommerceTests/WooCommerceTests.csproj
@@ -76,6 +76,7 @@
     <Compile Include="BatchListTests.cs" />
     <Compile Include="Helpers\DateTimeHelpersTests.cs" />
     <Compile Include="Helpers\LoggingHelperTests.cs" />
+    <Compile Include="Helpers\OrdersFiltersBuilderTests.cs" />
     <Compile Include="Helpers\UrlExtensionsTests.cs" />
     <Compile Include="Mappers\OrderMapperTests.cs" />
     <Compile Include="SettingsServiceTests.cs" />


### PR DESCRIPTION
Summary: Get WooCommerce orders by "dates_are_gmt"

#### Background
This tenant's WooCommerce API wasn't returning orders when queried by start/end UTC time: "modified_after": "2024-12-02T16:30:00.0000000Z", "modified_before": "2024-12-02T17:44:00.0000000Z". The "Z" on the end indicates UTC. This doesn't happen for all WooCommerce stores (the PBL-9226 customer or our WooCommerce cloud sandbox).

#### About these changes
- Filter orders by "modified_after" and "modified_before" date/times without explicit UTC marker ("Z") but instead explicitly pass the "dates_are_gmt" : "1" (true).
  - Tested on the sale 81256 (In ticket's attachment), which is in the WooCommerce store https://www.rangland.com/ of channel account 66309.
  - Also works for the PBL-9226 customer (IMHPurfume (358319), WooCommerce store `https://www.michaelmalul.com/`)
- [Add tests](https://github.com/skuvault-integrations/wooCommerceAccess/pull/66/files#diff-cdfec48d2400f9168360b2c3160d130fddf8449bac1bf0b0a128be1d520e237a) of the updated logic.

<!--
Help us understand what you did and why you did it. Provide a summary of your changes, including screenshots if appropriate.
-->

### PR Readiness Checklist

<!-- Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it. -->

- [x] I have updated all relevant configuration
- [x] Followed [development conventions][1] to the best of my ability
- [x] Code is documented, particularly public interfaces and hard-to-understand areas
- [x] Tests are updated / added and all pass
- [x] Performed a self-review of my own code
- [x] Acceptance criteria are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [x] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions
