### PR TITLE
PBL-9291 Filter Products by Dates

### DIFF
--- a/src/WooCommerceAccess/Helpers/DateTimeHelpers.cs
+++ b/src/WooCommerceAccess/Helpers/DateTimeHelpers.cs
@@ -8,6 +8,12 @@ namespace WooCommerceAccess.Helpers
 		/// Convert the start date to "sortable" date/time and round down to nearest minute (Linnworks reported issues otherwise).
 		/// See tickets PBL-9276, PBL-9291
 		/// </summary>
+		/// <example>
+		/// <code>
+		/// (new DateTime(2023, 10, 25, 14, 30, 45, 123, DateTimeKind.Utc)).ToWooCommerceStartDateTime();
+		/// // Result: "2023-10-25T14:30:00"
+		/// </code>
+		/// </example>
 		/// <param name="startDate"></param>
 		/// <returns></returns>
 		internal static string ToWooCommerceStartDateTime(this DateTime startDate)
@@ -18,6 +24,12 @@ namespace WooCommerceAccess.Helpers
 		/// <summary>
 		/// Convert the end date to "sortable" date/time and round up to the nearest minute (Linnworks reported issues otherwise).
 		/// </summary>
+		/// <example>
+		/// <code>
+		/// (new DateTime(2023, 10, 25, 14, 30, 45, 123, DateTimeKind.Utc)).ToWooCommerceEndDateTime();
+		/// // Result: "2023-10-25T14:31:00"
+		/// </code>
+		/// </example>
 		/// <param name="endDateTime"></param>
 		/// <returns></returns>
 		internal static string ToWooCommerceEndDateTime(this DateTime endDateTime)
@@ -40,6 +52,12 @@ namespace WooCommerceAccess.Helpers
 		/// <summary>
 		/// Round the date down to the nearest top of minute
 		/// </summary>
+		/// <example>
+		/// <code>
+		/// (new DateTime(2023, 10, 25, 14, 30, 45, 123, DateTimeKind.Utc)).RoundDateDownToTopOfMinute();
+		/// // Result: 10/25/2023 14:30:00
+		/// </code>
+		/// </example>
 		/// <remarks>Per Linnworks, for some clients orders aren't returned when query by date/times with non-zero seconds/ms</remarks>
 		/// <param name="dateTime"></param>
 		/// <returns></returns>
@@ -51,6 +69,12 @@ namespace WooCommerceAccess.Helpers
 		/// <summary>
 		/// Round the date up to the nearest top of minute
 		/// </summary>
+		/// <example>
+		/// <code>
+		/// (new DateTime(2023, 10, 25, 14, 30, 45, 123, DateTimeKind.Utc)).RoundDateUpToTopOfMinute();
+		/// // Result: 10/25/2023 14:31:00
+		/// </code>
+		/// </example>
 		/// <remarks>Per Linnworks, for some clients orders aren't returned when query by date/times with non-zero seconds/ms</remarks>
 		/// <param name="dateTime"></param>
 		/// <returns></returns>

--- a/src/WooCommerceAccess/Helpers/DateTimeHelpers.cs
+++ b/src/WooCommerceAccess/Helpers/DateTimeHelpers.cs
@@ -2,33 +2,68 @@
 
 namespace WooCommerceAccess.Helpers
 {
-    internal static class DateTimeHelpers
-    {
-        /// <summary>
-        /// Round the date down to the nearest top of minute
-        /// </summary>
-        /// <remarks>Per Linnworks, for some clients orders aren't returned when query by date/times with non-zero seconds/ms</remarks>
-        /// <param name="dateTime"></param>
-        /// <returns></returns>
-        internal static DateTime RoundDateDownToTopOfMinute(this DateTime dateTime)
-        {
-            return new DateTime(dateTime.Year, dateTime.Month, dateTime.Day, dateTime.Hour, dateTime.Minute, 0, dateTime.Kind);
-        }
+	internal static class DateTimeHelpers
+	{
+		//TODO PBL-9291 Add tests
+		/// <summary>
+		/// Convert the start date to "sortable" date/time and round down to nearest minute (Linnworks reported issues otherwise).
+		/// See tickets PBL-9276, PBL-9291
+		/// </summary>
+		/// <param name="startDate"></param>
+		/// <returns></returns>
+		internal static string ToWooCommerceStartDateTime(this DateTime startDate)
+		{
+			return startDate.RoundDateDownToTopOfMinute().ToSortableDate();
+		}
 
-        /// <summary>
-        /// Round the date up to the nearest top of minute
-        /// </summary>
-        /// <remarks>Per Linnworks, for some clients orders aren't returned when query by date/times with non-zero seconds/ms</remarks>
-        /// <param name="dateTime"></param>
-        /// <returns></returns>
-        internal static DateTime RoundDateUpToTopOfMinute(this DateTime dateTime)
-        {
-            if (dateTime.Second == 0 && dateTime.Millisecond == 0)
-            {
-                return dateTime;
-            }
-            var addOneMinute = dateTime.AddMinutes(1);
-            return new DateTime(addOneMinute.Year, addOneMinute.Month, addOneMinute.Day, addOneMinute.Hour, addOneMinute.Minute, 0, addOneMinute.Kind);
-        }
-    }
+		//TODO PBL-9291 Add tests
+		/// <summary>
+		/// Convert the end date to "sortable" date/time and round up to the nearest minute (Linnworks reported issues otherwise).
+		/// </summary>
+		/// <param name="endDateTime"></param>
+		/// <returns></returns>
+		internal static string ToWooCommerceEndDateTime(this DateTime endDateTime)
+		{
+			return endDateTime.RoundDateUpToTopOfMinute().ToSortableDate();
+		}
+
+		/// <summary>
+		/// Convert the date to "sortable" date/time format "s", since WooCommerce API sometimes doesn't filter correctly with the ISO format ("o").
+		/// See tickets PBL-9276, PBL-9291
+		/// Sortable format - <see href="https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#the-sortable-s-format-specifier"/>
+		/// </summary>
+		/// <param name="dateTime"></param>
+		/// <returns></returns>
+		private static string ToSortableDate(this DateTime dateTime)
+		{
+			return dateTime.ToString("s");
+		}
+
+		/// <summary>
+		/// Round the date down to the nearest top of minute
+		/// </summary>
+		/// <remarks>Per Linnworks, for some clients orders aren't returned when query by date/times with non-zero seconds/ms</remarks>
+		/// <param name="dateTime"></param>
+		/// <returns></returns>
+		internal static DateTime RoundDateDownToTopOfMinute(this DateTime dateTime)
+		{
+			return new DateTime(dateTime.Year, dateTime.Month, dateTime.Day, dateTime.Hour, dateTime.Minute, 0, dateTime.Kind);
+		}
+
+		/// <summary>
+		/// Round the date up to the nearest top of minute
+		/// </summary>
+		/// <remarks>Per Linnworks, for some clients orders aren't returned when query by date/times with non-zero seconds/ms</remarks>
+		/// <param name="dateTime"></param>
+		/// <returns></returns>
+		internal static DateTime RoundDateUpToTopOfMinute(this DateTime dateTime)
+		{
+			if (dateTime.Second == 0 && dateTime.Millisecond == 0)
+			{
+				return dateTime;
+			}
+			var addOneMinute = dateTime.AddMinutes(1);
+			return new DateTime(addOneMinute.Year, addOneMinute.Month, addOneMinute.Day, addOneMinute.Hour, addOneMinute.Minute, 0, addOneMinute.Kind);
+		}
+	}
 }

--- a/src/WooCommerceAccess/Helpers/DateTimeHelpers.cs
+++ b/src/WooCommerceAccess/Helpers/DateTimeHelpers.cs
@@ -4,7 +4,6 @@ namespace WooCommerceAccess.Helpers
 {
 	internal static class DateTimeHelpers
 	{
-		//TODO PBL-9291 Add tests
 		/// <summary>
 		/// Convert the start date to "sortable" date/time and round down to nearest minute (Linnworks reported issues otherwise).
 		/// See tickets PBL-9276, PBL-9291
@@ -16,7 +15,6 @@ namespace WooCommerceAccess.Helpers
 			return startDate.RoundDateDownToTopOfMinute().ToSortableDate();
 		}
 
-		//TODO PBL-9291 Add tests
 		/// <summary>
 		/// Convert the end date to "sortable" date/time and round up to the nearest minute (Linnworks reported issues otherwise).
 		/// </summary>

--- a/src/WooCommerceAccess/Helpers/OrdersFiltersBuilder.cs
+++ b/src/WooCommerceAccess/Helpers/OrdersFiltersBuilder.cs
@@ -13,9 +13,8 @@ namespace WooCommerceAccess.Helpers
             const string dateFilterBefore = "modified_before";
             var orderFilters = new Dictionary< string, string >
             {
-                //Sortable "s" format: https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#the-sortable-s-format-specifier
-                { dateFilterAfter, startDate.RoundDateDownToTopOfMinute().ToString( "s" ) },
-                { dateFilterBefore, endDate.RoundDateUpToTopOfMinute().ToString( "s" ) }
+                { dateFilterAfter, startDate.ToWooCommerceStartDateTime() },
+                { dateFilterBefore, endDate.ToWooCommerceEndDateTime() }
             };
             if ( startDate.Kind == DateTimeKind.Utc && endDate.Kind == DateTimeKind.Utc )
             {

--- a/src/WooCommerceAccess/Helpers/ProductsFiltersBuilder.cs
+++ b/src/WooCommerceAccess/Helpers/ProductsFiltersBuilder.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace WooCommerceAccess.Helpers
+{
+	public static class ProductsFiltersBuilder
+	{
+		private const string DatesAreGmt = "dates_are_gmt";
+
+		//TODO PBL-9291 Add unit tests
+		internal static Dictionary<string, string> CreateProductStartDateTimeFilters(DateTime startDateUtc,
+			bool includeUpdated)
+		{
+			var dateFilter = includeUpdated ? "modified_after" : "after";
+			var productFilters = new Dictionary<string, string>
+			{
+				{ dateFilter, startDateUtc.ToWooCommerceStartDateTime() }
+			};
+
+			if (startDateUtc.Kind == DateTimeKind.Utc)
+			{
+				productFilters.Add(DatesAreGmt, "1");
+			}
+
+			return productFilters;
+		}
+	}
+}

--- a/src/WooCommerceAccess/Helpers/ProductsFiltersBuilder.cs
+++ b/src/WooCommerceAccess/Helpers/ProductsFiltersBuilder.cs
@@ -5,9 +5,14 @@ namespace WooCommerceAccess.Helpers
 {
 	public static class ProductsFiltersBuilder
 	{
-		private const string DatesAreGmt = "dates_are_gmt";
+		internal const string DatesAreGmt = "dates_are_gmt";
 
-		//TODO PBL-9291 Add unit tests
+		/// <summary>
+		/// Create the filter to query for products by modified/created start date/time
+		/// </summary>
+		/// <param name="startDateUtc"></param>
+		/// <param name="includeUpdated">If true, filter by both the created and updated dates. Otherwise, only created date</param>
+		/// <returns></returns>
 		internal static Dictionary<string, string> CreateProductStartDateTimeFilters(DateTime startDateUtc,
 			bool includeUpdated)
 		{

--- a/src/WooCommerceAccess/Services/ApiV3WCObject.cs
+++ b/src/WooCommerceAccess/Services/ApiV3WCObject.cs
@@ -71,6 +71,12 @@ namespace WooCommerceAccess.Services
 			var dateFilter = includeUpdated ? "modified_after" : "after";
 			var productFilters = new Dictionary< string, string >
 			{
+				//TODO PBL-9291 In this ticket's v1 PR, will now always send startDateTime as UTC. When we did this earlier for orders, it cased an issue for at least one tenant (PBL-9276).
+				//	Test if the v1 change didn't now introduce the same issue for Products (possibly on the PBL-9276 tenant).
+				//	If yes, then implement for products the same fix we did for Orders - https://github.com/skuvault-integrations/wooCommerceAccess/pull/66
+				//	Below, we'd the date to "sortable" format (no Z) and then add "dates_are_gmt" if UTC. 
+				//		Might be good to extract both fixes into common extensions methods - ToDateTimeStartFilterValue (format as “s” and round down to nearest minute) and ToDateTimeEndFilterValue (format as “s” and round up to nearest minute)
+				//		{ dateFilter, startDate.RoundDateDownToTopOfMinute().ToString( "s" ) },
 				{ dateFilter, startDateUtc.ToString( "o" ) }
 			};
 
@@ -230,6 +236,9 @@ namespace WooCommerceAccess.Services
 		{
 			var productsWithinPage = await this.WooCommerceNetObjectV3.Product.GetAll( filter ).ConfigureAwait( false );
 
+			//TODO PBL-9291 Log filter as well (see Orders sync for examples)
+			//See WooCommerceLogger.LogTrace( Misc.CreateMethodCallInfo( url, mark, additionalInfo:
+			//$"Orders Received on page {page}: {wooCommerceOrders.ToJson()}", queryStringParams: combinedFilters ) );
 			WooCommerceLogger.LogTrace( Misc.CreateMethodCallInfo( url, mark, payload: string.Format( "Products Received: {0}" , productsWithinPage.ToJson() ) ) );
 
 			var svProductsWithinPage = productsWithinPage.Select( p => p.ToSvProduct() ).ToList();

--- a/src/WooCommerceAccess/Services/ApiV3WCObject.cs
+++ b/src/WooCommerceAccess/Services/ApiV3WCObject.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using CuttingEdge.Conditions;
+using WooCommerceAccess.Helpers;
 using WooCommerceAccess.Models;
 using WooCommerceAccess.Models.Configuration;
 using WooCommerceAccess.Shared;
@@ -68,18 +69,7 @@ namespace WooCommerceAccess.Services
 
 		public async Task< IEnumerable< WooCommerceProduct > > GetProductsAsync( DateTime startDateUtc, bool includeUpdated, int pageSize, string url, Mark mark )
 		{
-			var dateFilter = includeUpdated ? "modified_after" : "after";
-			var productFilters = new Dictionary< string, string >
-			{
-				//TODO PBL-9291 In this ticket's v1 PR, will now always send startDateTime as UTC. When we did this earlier for orders, it cased an issue for at least one tenant (PBL-9276).
-				//	Test if the v1 change didn't now introduce the same issue for Products (possibly on the PBL-9276 tenant).
-				//	If yes, then implement for products the same fix we did for Orders - https://github.com/skuvault-integrations/wooCommerceAccess/pull/66
-				//	Below, we'd the date to "sortable" format (no Z) and then add "dates_are_gmt" if UTC. 
-				//		Might be good to extract both fixes into common extensions methods - ToDateTimeStartFilterValue (format as “s” and round down to nearest minute) and ToDateTimeEndFilterValue (format as “s” and round up to nearest minute)
-				//		{ dateFilter, startDate.RoundDateDownToTopOfMinute().ToString( "s" ) },
-				{ dateFilter, startDateUtc.ToString( "o" ) }
-			};
-
+			var productFilters = ProductsFiltersBuilder.CreateProductStartDateTimeFilters( startDateUtc, includeUpdated );
 			var products = await CollectProductsFromAllPagesAsync( productFilters, pageSize, url, mark );
 			return products;
 		}

--- a/src/WooCommerceAccess/Services/ApiV3WCObject.cs
+++ b/src/WooCommerceAccess/Services/ApiV3WCObject.cs
@@ -226,10 +226,8 @@ namespace WooCommerceAccess.Services
 		{
 			var productsWithinPage = await this.WooCommerceNetObjectV3.Product.GetAll( filter ).ConfigureAwait( false );
 
-			//TODO PBL-9291 Log filter as well (see Orders sync for examples)
-			//See WooCommerceLogger.LogTrace( Misc.CreateMethodCallInfo( url, mark, additionalInfo:
-			//$"Orders Received on page {page}: {wooCommerceOrders.ToJson()}", queryStringParams: combinedFilters ) );
-			WooCommerceLogger.LogTrace( Misc.CreateMethodCallInfo( url, mark, payload: string.Format( "Products Received: {0}" , productsWithinPage.ToJson() ) ) );
+			WooCommerceLogger.LogTrace( Misc.CreateMethodCallInfo( url, mark,
+				additionalInfo: $"Page of Products Received: {productsWithinPage.ToJson()}", queryStringParams: filter ) );
 
 			var svProductsWithinPage = productsWithinPage.Select( p => p.ToSvProduct() ).ToList();
 

--- a/src/WooCommerceAccess/WooCommerceAccess.csproj
+++ b/src/WooCommerceAccess/WooCommerceAccess.csproj
@@ -9,13 +9,13 @@
     <PackageLicenseUrl>https://github.com/skuvault/wooCommerceAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/wooCommerceAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault-integrations/wooCommerceAccess.git</RepositoryUrl>
-    <Version>1.11.9</Version>
+    <Version>1.11.10</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.11.9.0</AssemblyVersion>
-    <FileVersion>1.11.9.0</FileVersion>
+    <AssemblyVersion>1.11.10.0</AssemblyVersion>
+    <FileVersion>1.11.10.0</FileVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <RepositoryType>git</RepositoryType>
-    <PackageVersion>1.11.9-alpha.1</PackageVersion>
+    <PackageVersion>1.11.10-alpha.1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WooCommerceAccess/WooCommerceAccess.csproj
+++ b/src/WooCommerceAccess/WooCommerceAccess.csproj
@@ -9,13 +9,13 @@
     <PackageLicenseUrl>https://github.com/skuvault/wooCommerceAccess/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/wooCommerceAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault-integrations/wooCommerceAccess.git</RepositoryUrl>
-    <Version>1.11.8</Version>
+    <Version>1.11.9</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.11.8.0</AssemblyVersion>
-    <FileVersion>1.11.8.0</FileVersion>
+    <AssemblyVersion>1.11.9.0</AssemblyVersion>
+    <FileVersion>1.11.9.0</FileVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <RepositoryType>git</RepositoryType>
-    <PackageVersion>1.11.8</PackageVersion>
+    <PackageVersion>1.11.9-alpha.1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WooCommerceTests/Helpers/ProductsFiltersBuilderTests.cs
+++ b/src/WooCommerceTests/Helpers/ProductsFiltersBuilderTests.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using NUnit.Framework;
+using WooCommerceAccess.Helpers;
+
+namespace WooCommerceTests.Helpers
+{
+	public class ProductsFiltersBuilderTests
+	{
+		[TestCase(true)]
+		[TestCase(false)]
+		public void CreateProductStartDateTimeFilters_ShouldSetDatesAreGmtToTrue_WhenDateIsUtc(bool includeUpdated)
+		{
+			var startDate = new DateTime(2001, 1, 1, 1, 1, 1, DateTimeKind.Utc);
+
+			var result = ProductsFiltersBuilder.CreateProductStartDateTimeFilters(startDate, includeUpdated);
+
+			Assert.That(result[ProductsFiltersBuilder.DatesAreGmt], Is.EqualTo("1"));
+		}
+
+		[TestCase(DateTimeKind.Unspecified, true)]
+		[TestCase(DateTimeKind.Local, true)]
+		[TestCase(DateTimeKind.Unspecified, false)]
+		[TestCase(DateTimeKind.Local, false)]
+		public void CreateProductStartDateTimeFilters_ShouldNotSetDatesAreGmtToTrue_WhenDateIsNotUtc(
+			DateTimeKind startDateKind, bool includeUpdated)
+		{
+			var startDate = new DateTime(2001, 1, 1, 1, 1, 1, startDateKind);
+
+			var result = ProductsFiltersBuilder.CreateProductStartDateTimeFilters(startDate, includeUpdated: true);
+
+			Assert.That(result.ContainsKey(ProductsFiltersBuilder.DatesAreGmt), Is.False);
+		}
+
+		[Test]
+		public void CreateProductStartDateTimeFilters_ShouldFilterByModifiedDate_WhenIncludeUpdatedIsTrue()
+		{
+			var result = ProductsFiltersBuilder.CreateProductStartDateTimeFilters(DateTime.UtcNow, includeUpdated: true);
+
+			Assert.Multiple(() => {
+				Assert.That(result.ContainsKey("modified_after"), Is.True);
+				Assert.That(result.ContainsKey("after"), Is.False);
+			});
+		}
+
+		[Test]
+		public void CreateProductStartDateTimeFilters_ShouldFilterByCreatedDate_WhenIncludeUpdatedIsFalse()
+		{
+			var result = ProductsFiltersBuilder.CreateProductStartDateTimeFilters(DateTime.UtcNow, includeUpdated: false);
+
+			Assert.Multiple(() => {
+				Assert.That(result.ContainsKey("after"), Is.True);
+				Assert.That(result.ContainsKey("modified_after"), Is.False);
+			});
+		}
+	}
+}

--- a/src/WooCommerceTests/WooCommerceTests.csproj
+++ b/src/WooCommerceTests/WooCommerceTests.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Helpers\DateTimeHelpersTests.cs" />
     <Compile Include="Helpers\LoggingHelperTests.cs" />
     <Compile Include="Helpers\OrdersFiltersBuilderTests.cs" />
+    <Compile Include="Helpers\ProductsFiltersBuilderTests.cs" />
     <Compile Include="Helpers\UrlExtensionsTests.cs" />
     <Compile Include="Mappers\OrderMapperTests.cs" />
     <Compile Include="SettingsServiceTests.cs" />


### PR DESCRIPTION
[PBL-9291]
Summary: Filter for products by min creation/update date using the "sortable" date/time format, round down to the nearest minute and send "dates_are_gmt" param.

#### Background
WooCommerce products aren't getting pulled into this tenant's catalog (newly created, but presumably neither do updated).

#### About these changes
**Root cause**: Apparently, products aren't being returned from the Woo API because the data/time filter is passed from v1 as `DateTimeKind.Unspecified` and isn't correctly passed to WooCommerce. The same issue happened for orders (was fixed in [PBL-9276](https://linnworks.atlassian.net/browse/PBL-9276))
**Solution**
* In the [v1 PR](https://github.com/skuvault/skuvault-v1/pull/1741/), will pass the filter startDateUtc with `DateTimeKind.Utc`
* Here in access:
  * Serialize the passed-in from v1 date as "sortable" date/time format, round down to the nearest minute and send "dates_are_gmt" param.
  * [Refactor] Extract product filter creation into [ProductsFiltersBuilder](https://github.com/skuvault-integrations/wooCommerceAccess/pull/68/files?diff=split&w=1#diff-9adede44c681b175a0ee33dde5469ed91887931e454665083195aac38664a970R16).
  * [Refactor] Extract the ToSortableDate(), ToWooCommerceStartDateTime() & ToWooCommerceEndDateTime() into [DateTimeHelpers](https://github.com/skuvault-integrations/wooCommerceAccess/pull/68/files?diff=split&w=1#diff-6f16ec0c92293aab5c5f474f2acae32154be7464021f7ba24c1f841ecf1732b5R13-R39), for better modularity and since the 1st two methods are now called for both orders and products.
  * [Refactor] Improve the `GET` Products API endpoint [logging](https://github.com/skuvault-integrations/wooCommerceAccess/pull/68/files?diff=split&w=1#diff-34575e21545d27acd6452439933c2aa6f7de9562cb6762757241b00b4011a09aR229-R230) (similarly to Orders earlier).
  * Add tests for updated, created code.

<!--
Help us understand what you did and why you did it. Provide a summary of your changes, including screenshots if appropriate.
-->

### PR Readiness Checklist

<!-- Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it. -->

- [x] I have updated all relevant configuration
- [x] Followed [development conventions][1] to the best of my ability
- [x] Code is documented, particularly public interfaces and hard-to-understand areas
- [x] Tests are updated / added and all pass
- [x] Performed a self-review of my own code
- [ ] Acceptance criteria are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [x] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions


[PBL-9291]: https://linnworks.atlassian.net/browse/PBL-9291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PBL-9276]: https://linnworks.atlassian.net/browse/PBL-9276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ